### PR TITLE
Lowered Osmium EMC

### DIFF
--- a/src/main/java/moze_intel/projecte/emc/EMCMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/EMCMapper.java
@@ -589,7 +589,7 @@ public final class EMCMapper
 		addMapping("ingotDarkSteel", 384);
 		addMapping("ingotSoularium", 2097);
 		/*Mekanism*/
-		addMapping("ingotOsmium", 2496);
+		addMapping("ingotOsmium", 128);
 			
 		//AE2
 		addMapping("crystalCertusQuartz", 64);


### PR DESCRIPTION
Made osmium's EMC to 128 to put it in line with other common ores.
